### PR TITLE
feat(core): implement windowLayout helper function

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -167,3 +167,4 @@ export function buildLayout(
 }
 
 export { USER_BRACKET, USER_BRACKET_RAW, toBracketInput } from './samples';
+export { windowLayout } from './windowLayout.js';

--- a/packages/core/src/test/__fixtures__/sampleLayouts.ts
+++ b/packages/core/src/test/__fixtures__/sampleLayouts.ts
@@ -1,0 +1,21 @@
+import type { BracketInput, Match } from '../../index.js';
+
+// 4-round sample tournament (8 participants -> 4 -> 2 -> 1)
+export const SAMPLE_4_ROUND_MATCHES: Match[] = [
+  // Round 1 (8 -> 4)
+  { id: 'r1m1', winnerNextMatchId: 'r2m1', left: { name: 'Team A', seed: 1 }, right: { name: 'Team H', seed: 8 } },
+  { id: 'r1m2', winnerNextMatchId: 'r2m1', left: { name: 'Team D', seed: 4 }, right: { name: 'Team E', seed: 5 } },
+  { id: 'r1m3', winnerNextMatchId: 'r2m2', left: { name: 'Team B', seed: 2 }, right: { name: 'Team G', seed: 7 } },
+  { id: 'r1m4', winnerNextMatchId: 'r2m2', left: { name: 'Team C', seed: 3 }, right: { name: 'Team F', seed: 6 } },
+  
+  // Round 2 - Semifinals (4 -> 2)  
+  { id: 'r2m1', winnerNextMatchId: 'r3m1', left: null, right: null },
+  { id: 'r2m2', winnerNextMatchId: 'r3m1', left: null, right: null },
+  
+  // Round 3 - Finals (2 -> 1)
+  { id: 'r3m1', winnerNextMatchId: null, left: null, right: null }
+];
+
+export const SAMPLE_4_ROUND_BRACKET: BracketInput = {
+  matches: SAMPLE_4_ROUND_MATCHES
+};

--- a/packages/core/src/windowLayout.test.ts
+++ b/packages/core/src/windowLayout.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { windowLayout, buildLayout } from './index.js';
+import { SAMPLE_4_ROUND_BRACKET } from './test/__fixtures__/sampleLayouts.js';
+import type { Layout, LayoutNode, LayoutEdge } from './index.js';
+
+describe('windowLayout', () => {
+  let sampleLayout: Layout;
+
+  beforeAll(() => {
+    // Build a 4-round layout for testing
+    sampleLayout = buildLayout(SAMPLE_4_ROUND_BRACKET);
+  });
+
+  it('should filter nodes by round range [1,3)', () => {
+    const result = windowLayout(sampleLayout, 1, 3);
+    
+    // Should include rounds 1 and 2, exclude round 3
+    const resultRounds = result.nodes.map((n: LayoutNode) => n.round);
+    expect(Math.min(...resultRounds)).toBe(1);
+    expect(Math.max(...resultRounds)).toBe(2);
+    
+    // Should have nodes from rounds 1 and 2 only
+    const round1Nodes = result.nodes.filter((n: LayoutNode) => n.round === 1);
+    const round2Nodes = result.nodes.filter((n: LayoutNode) => n.round === 2);
+    const round3Nodes = result.nodes.filter((n: LayoutNode) => n.round === 3);
+    
+    expect(round1Nodes.length).toBeGreaterThan(0);
+    expect(round2Nodes.length).toBeGreaterThan(0);
+    expect(round3Nodes.length).toBe(0);
+  });
+
+  it('should preserve original node coordinates and round numbers', () => {
+    const result = windowLayout(sampleLayout, 1, 3);
+    
+    // Find a node that exists in both original and filtered
+    const originalNode = sampleLayout.nodes.find((n: LayoutNode) => n.round === 1);
+    const filteredNode = result.nodes.find((n: LayoutNode) => n.id === originalNode?.id);
+    
+    expect(filteredNode).toBeDefined();
+    expect(filteredNode!.x).toBe(originalNode!.x);
+    expect(filteredNode!.y).toBe(originalNode!.y);
+    expect(filteredNode!.round).toBe(originalNode!.round);
+  });
+
+  it('should keep only edges whose endpoints remain', () => {
+    const result = windowLayout(sampleLayout, 1, 3);
+    const remainingNodeIds = new Set(result.nodes.map((n: LayoutNode) => n.id));
+    
+    // All edges should have both endpoints in the remaining nodes
+    for (const edge of result.edges) {
+      expect(remainingNodeIds.has(edge.from)).toBe(true);
+      expect(remainingNodeIds.has(edge.to)).toBe(true);
+    }
+  });
+
+  it('should return empty layout for invalid window ranges', () => {
+    // Start >= end
+    let result = windowLayout(sampleLayout, 3, 3);
+    expect(result.nodes).toHaveLength(0);
+    expect(result.edges).toHaveLength(0);
+    expect(result.rounds).toHaveLength(0);
+    
+    // Start > end
+    result = windowLayout(sampleLayout, 4, 2);
+    expect(result.nodes).toHaveLength(0);
+    expect(result.edges).toHaveLength(0);
+    expect(result.rounds).toHaveLength(0);
+  });
+
+  it('should handle out-of-range clamping', () => {
+    // Request range beyond available rounds
+    const result = windowLayout(sampleLayout, -5, 100);
+    
+    // Should clamp to actual range of the layout
+    const minRound = Math.min(...sampleLayout.nodes.map((n: LayoutNode) => n.round));
+    const maxRound = Math.max(...sampleLayout.nodes.map((n: LayoutNode) => n.round));
+    
+    const resultMinRound = Math.min(...result.nodes.map((n: LayoutNode) => n.round));
+    const resultMaxRound = Math.max(...result.nodes.map((n: LayoutNode) => n.round));
+    
+    expect(resultMinRound).toBe(minRound);
+    expect(resultMaxRound).toBe(maxRound);
+  });
+
+  it('should be deterministic with stable sorting', () => {
+    const result1 = windowLayout(sampleLayout, 1, 4);
+    const result2 = windowLayout(sampleLayout, 1, 4);
+    
+    // Node order should be identical
+    expect(result1.nodes.map((n: LayoutNode) => n.id)).toEqual(result2.nodes.map((n: LayoutNode) => n.id));
+    
+    // Edge order should be identical
+    expect(result1.edges.map((e: LayoutEdge) => `${e.from}->${e.to}`))
+      .toEqual(result2.edges.map((e: LayoutEdge) => `${e.from}->${e.to}`));
+  });
+
+  it('should not mutate the input layout (purity test)', () => {
+    const originalNodes = [...sampleLayout.nodes];
+    const originalEdges = [...sampleLayout.edges];
+    const originalRounds = sampleLayout.rounds.map((round: string[]) => [...round]);
+    
+    // Perform windowing operation
+    windowLayout(sampleLayout, 1, 3);
+    
+    // Verify original layout is unchanged
+    expect(sampleLayout.nodes).toEqual(originalNodes);
+    expect(sampleLayout.edges).toEqual(originalEdges);
+    expect(sampleLayout.rounds).toEqual(originalRounds);
+  });
+
+  it('should filter rounds property correctly', () => {
+    const result = windowLayout(sampleLayout, 1, 3);
+    
+    // Should have 2 rounds (1 and 2)
+    expect(result.rounds).toHaveLength(2);
+    
+    // Each round should contain only match IDs that are in the filtered nodes
+    const nodeIds = new Set(result.nodes.map((n: LayoutNode) => n.id));
+    for (const round of result.rounds) {
+      for (const matchId of round) {
+        expect(nodeIds.has(matchId)).toBe(true);
+      }
+    }
+  });
+
+  it('should handle single round window', () => {
+    const result = windowLayout(sampleLayout, 2, 3);
+    
+    // Should contain only round 2
+    const rounds = result.nodes.map((n: LayoutNode) => n.round);
+    expect(Math.min(...rounds)).toBe(2);
+    expect(Math.max(...rounds)).toBe(2);
+    expect(result.rounds).toHaveLength(1);
+  });
+});

--- a/packages/core/src/windowLayout.ts
+++ b/packages/core/src/windowLayout.ts
@@ -1,0 +1,82 @@
+import type { Layout, LayoutNode, LayoutEdge, MatchId } from './index.js';
+
+/**
+ * Creates a filtered view of a bracket layout containing only nodes and edges 
+ * within the specified round range [startRound, endRound).
+ * 
+ * This is useful for displaying only a portion of a large bracket, such as
+ * showing rounds 1-3 of an 8-round tournament.
+ * 
+ * @param layout - The complete bracket layout to filter
+ * @param startRound - The first round to include (inclusive)
+ * @param endRound - The last round to exclude (exclusive)
+ * @returns A new Layout containing only nodes and edges in the specified window
+ * 
+ * @example
+ * ```typescript
+ * // Show only rounds 1-3 (rounds 1 and 2)
+ * const window = windowLayout(fullBracket, 1, 3);
+ * 
+ * // Show semifinals and finals (rounds 3-4 in a 4-round bracket)
+ * const finalRounds = windowLayout(bracket, 3, 5);
+ * ```
+ */
+export function windowLayout(
+  layout: Layout,
+  startRound: number,
+  endRound: number
+): Layout {
+  // Clamp the range to valid bounds
+  const minRound = Math.min(...layout.nodes.map((n: LayoutNode) => n.round));
+  const maxRound = Math.max(...layout.nodes.map((n: LayoutNode) => n.round));
+  
+  const clampedStart = Math.max(startRound, minRound);
+  const clampedEnd = Math.min(endRound, maxRound + 1);
+  
+  // If the window is invalid or empty, return empty layout
+  if (clampedStart >= clampedEnd) {
+    return {
+      nodes: [],
+      edges: [],
+      rounds: []
+    };
+  }
+  
+  // Filter nodes by round range, keeping original coordinates and round numbers
+  const filteredNodes = layout.nodes
+    .filter((node: LayoutNode) => node.round >= clampedStart && node.round < clampedEnd)
+    .sort((a: LayoutNode, b: LayoutNode) => a.id.localeCompare(b.id)); // Deterministic sort by id
+  
+  // Create a set of remaining node IDs for efficient lookup
+  const remainingNodeIds = new Set(filteredNodes.map((node: LayoutNode) => node.id));
+  
+  // Filter edges - keep only edges where both endpoints remain
+  const filteredEdges = layout.edges
+    .filter((edge: LayoutEdge) => 
+      remainingNodeIds.has(edge.from) && 
+      remainingNodeIds.has(edge.to)
+    )
+    .sort((a: LayoutEdge, b: LayoutEdge) => {
+      // Deterministic sort by from-to pair
+      const fromComp = a.from.localeCompare(b.from);
+      return fromComp !== 0 ? fromComp : a.to.localeCompare(b.to);
+    });
+  
+  // Filter rounds - keep only rounds within the window and filter match IDs
+  const filteredRounds: MatchId[][] = [];
+  for (let roundIndex = 0; roundIndex < layout.rounds.length; roundIndex++) {
+    const roundNumber = roundIndex + 1; // rounds are 1-indexed in the layout
+    if (roundNumber >= clampedStart && roundNumber < clampedEnd) {
+      const roundMatches = layout.rounds[roundIndex].filter((matchId: MatchId) => 
+        remainingNodeIds.has(matchId)
+      );
+      filteredRounds.push(roundMatches);
+    }
+  }
+  
+  return {
+    nodes: filteredNodes,
+    edges: filteredEdges,
+    rounds: filteredRounds
+  };
+}


### PR DESCRIPTION
- Add windowLayout function to filter layouts by round range [startRound, endRound)
- Pure function that preserves node coordinates and round numbers
- Filters edges to keep only those whose endpoints remain
- Handles out-of-range clamping and empty windows
- Deterministic output with stable sorting
- Comprehensive test coverage including purity, range slicing, and edge cases
- Export from @mgi/bracket-core index

Closes #7